### PR TITLE
Added android-maven plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
-
+        classpath 'com.github.dcendents:android-maven-plugin:1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/circualreveal/build.gradle
+++ b/circualreveal/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'android-maven'
 
 android {
     compileSdkVersion 21


### PR DESCRIPTION
With android-maven plugin CircularReveal can now be installed in the local maven repository:

    gradle install

In addition its now possible to get it as a maven dependency:
https://jitpack.io/#jitpack/CircularReveal/1.0.4

once these changes are included in a new release.
