### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Use regular `RevealFrameLayout` & `RevealLinearLayout` don't worry, only target 
 How to add dependency
 =====================
 
-This library is not released in Maven Central, but instead you can use [JitPak](https://www.jitpack.io/)
+This library is not released in Maven Central, but instead you can use [JitPack](https://www.jitpack.io/)
 
 add remote maven url
 
@@ -88,7 +88,7 @@ then add a library dependency
 
 ```groovy
 	dependencies {
-	    compile 'com.github.ozodrukh:CircularReveal:(latest-release)'
+	    compile 'com.github.ozodrukh:CircularReveal:(latest-release)@aar'
 	}
 ```
 


### PR DESCRIPTION
Fixed typo and added 'aar' dependency type.
Btw, you'd need to have a new release (1.0.4) in order to enable jitpack since older releases don't have the maven plugin.