### PR TITLE
Changed API for hardware acceleration from 17 to 18.

### DIFF
--- a/circualreveal/src/main/java/io/codetail/animation/RevealAnimator.java
+++ b/circualreveal/src/main/java/io/codetail/animation/RevealAnimator.java
@@ -94,14 +94,14 @@ public interface RevealAnimator{
         }
     }
 
-    static class RevealFinishedJellyBeanMr1 extends SimpleAnimationListener {
+    static class RevealFinishedJellyBeanMr2 extends SimpleAnimationListener {
         WeakReference<RevealAnimator> mReference;
         volatile Rect mInvalidateBounds;
 
         int mLayerType;
 
         @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-        RevealFinishedJellyBeanMr1(RevealAnimator target, Rect bounds) {
+        RevealFinishedJellyBeanMr2(RevealAnimator target, Rect bounds) {
             mReference = new WeakReference<>(target);
             mInvalidateBounds = bounds;
 

--- a/circualreveal/src/main/java/io/codetail/animation/ViewAnimationUtils.java
+++ b/circualreveal/src/main/java/io/codetail/animation/ViewAnimationUtils.java
@@ -67,8 +67,8 @@ public class ViewAnimationUtils {
 
 
     static Animator.AnimatorListener getRevealFinishListener(RevealAnimator target, Rect bounds){
-        if(SDK_INT >= 17){
-            return new RevealAnimator.RevealFinishedJellyBeanMr1(target, bounds);
+        if(SDK_INT >= 18){
+            return new RevealAnimator.RevealFinishedJellyBeanMr2(target, bounds);
         }else if(SDK_INT >= 14){
             return new RevealAnimator.RevealFinishedIceCreamSandwich(target, bounds);
         }else {


### PR DESCRIPTION
As you can see from these two issues:
https://github.com/ozodrukh/CircularReveal/issues/11
https://github.com/Yalantis/Euclid/issues/2

there is a bug with "square" animation due to hardware acceleration.

Due to documentation: [http://developer.android.com/guide/topics/graphics/hardware-accel.html#unsupported] 
clipPath() which is used for circle clipping is supported starting from API 18. So I've made some little changes to fix that issue.