### PR TITLE
Fix reveal layout invalidation rect refresh

### DIFF
--- a/circualreveal/src/main/java/io/codetail/widget/RevealFrameLayout.java
+++ b/circualreveal/src/main/java/io/codetail/widget/RevealFrameLayout.java
@@ -57,6 +57,7 @@ public class RevealFrameLayout extends FrameLayout implements RevealAnimator{
     @Override
     public void setRevealRadius(float radius){
         mRadius = radius;
+        mRevealInfo.getTarget().getHitRect(mTargetBounds);
         invalidate(mTargetBounds);
     }
 
@@ -75,7 +76,6 @@ public class RevealFrameLayout extends FrameLayout implements RevealAnimator{
      */
     @Override
     public void attachRevealInfo(RevealInfo info) {
-        info.getTarget().getHitRect(mTargetBounds);
         mRevealInfo = info;
     }
 

--- a/circualreveal/src/main/java/io/codetail/widget/RevealLinearLayout.java
+++ b/circualreveal/src/main/java/io/codetail/widget/RevealLinearLayout.java
@@ -57,6 +57,7 @@ public class RevealLinearLayout extends LinearLayout implements RevealAnimator{
     @Override
     public void setRevealRadius(float radius){
         mRadius = radius;
+        mRevealInfo.getTarget().getHitRect(mTargetBounds);
         invalidate(mTargetBounds);
     }
 
@@ -75,7 +76,6 @@ public class RevealLinearLayout extends LinearLayout implements RevealAnimator{
      */
     @Override
     public void attachRevealInfo(RevealInfo info) {
-        info.getTarget().getHitRect(mTargetBounds);
         mRevealInfo = info;
     }
 


### PR DESCRIPTION
If the view that is being revealed is not layed out (e.g. the view's
visibility was set to GONE), when the support reveal animation is
created, the target invalidation rect is empty, and the animation is not
drawn.