### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ then add a library dependency
 
 ```groovy
 	dependencies {
-	    compile 'com.github.ozodrukh:CircularReveal:1.1.1@aar'
+	    compile ('com.github.ozodrukh:CircularReveal:1.1.1@aar') {
+	        transitive = true;
+	    }
 	}
 ```
 


### PR DESCRIPTION
Update README. Use transitive = true to avoid NoClassDefFoundError due to a dependency that is not included into a build.