### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ then add a library dependency
 
 ```groovy
 	dependencies {
-	    compile ('com.github.ozodrukh:CircularReveal:2.0.1@aar') {
+	    implementation ('com.github.ozodrukh:CircularReveal:2.0.1@aar') {
 	        transitive = true;
 	    }
 	}


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.