### PR TITLE
Fix use of Canvas.clipPath with hardware acceleration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 
 
 ext {
-  minSDKVersion = 16
+  minSDKVersion = 15
   targetSDKVersion = 25
   compileSDKVersion = 25
   buildToolsVersion = BUILD_TOOLS_VERSION

--- a/circualreveal/src/main/java/io/codetail/widget/RevealFrameLayout.java
+++ b/circualreveal/src/main/java/io/codetail/widget/RevealFrameLayout.java
@@ -2,6 +2,7 @@ package io.codetail.widget;
 
 import android.content.Context;
 import android.graphics.Canvas;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -21,6 +22,11 @@ public class RevealFrameLayout extends FrameLayout implements RevealViewGroup {
 
   public RevealFrameLayout(Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
+    // https://developer.android.com/guide/topics/graphics/hardware-accel.html#unsupported
+    // in theory the first part of this if could be omitted, but I'll leave it there to make the version range clear
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    }
 
     manager = new ViewRevealManager();
   }


### PR DESCRIPTION
After a few months, finally :-) a fix for #100.
I've also included - in a separate commit - minSdkVersion downgrade to 15, but that's for my own purposes - and it works anyway, so I don't see a reason for not doing so. You're free to skip that commit of course, but I'll need to keep my fork in case you do.